### PR TITLE
Fix compilation after updating to EspHome 2026.3.2

### DIFF
--- a/components/canopen/fw.h
+++ b/components/canopen/fw.h
@@ -5,7 +5,7 @@
 
 #ifdef USE_CANOPEN_OTA
 
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 
 /******************************************************************************
  * INCLUDES

--- a/components/canopen/ota/ota.cpp
+++ b/components/canopen/ota/ota.cpp
@@ -1,7 +1,7 @@
 #include "ota.h"
 // #ifdef USE_OTA
 #include "esphome/components/md5/md5.h"
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 #include "esphome/components/ota/ota_backend_esp_idf.h"
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"

--- a/components/canopen/ota/ota.cpp
+++ b/components/canopen/ota/ota.cpp
@@ -23,37 +23,29 @@ void CanopenOTAComponent::setup() {
 
   ota_finished_trigger = new canopen::OtaFinishedTrigger();
   auto automation_id = new Automation<>(ota_finished_trigger);
-  auto delayaction_id = new DelayAction<>();
-  auto delayaction2_id = new DelayAction<>();
 
-  delayaction_id->set_component_source(LOG_STR("canopen.ota"));
-  App.register_component(delayaction_id);
-  delayaction_id->set_delay(1000);
+  auto ota_end_id = new LambdaAction<>([this]() -> void {
+    App.scheduler.set_timeout(this, "ota_timeout", 1000, [this]() {
+      esphome::ota::OTAResponseTypes ret = esphome::ota::OTAResponseTypes::OTA_RESPONSE_OK;
+      if(!dry_run) {
+        ret = backend->end();
+      }
+      if(ret == esphome::ota::OTAResponseTypes::OTA_RESPONSE_OK) {
+        ESP_LOGI(TAG, "ota finished successfully, rebooting");
+      } else {
+        ESP_LOGE(TAG, "ota error: %d", ret);
+      }
 
-  delayaction2_id->set_component_source(LOG_STR("canopen.ota"));
-  App.register_component(delayaction2_id);
-  delayaction2_id->set_delay(1000);
-
-  auto ota_end_id = new LambdaAction<>([=]() -> void {
-    esphome::ota::OTAResponseTypes ret = esphome::ota::OTAResponseTypes::OTA_RESPONSE_OK;
-    if(!dry_run) {
-      ret = backend->end();
-    }
-    if(ret == esphome::ota::OTAResponseTypes::OTA_RESPONSE_OK) {
-      ESP_LOGI(TAG, "ota finished successfully, rebooting");
-    } else {
-      ESP_LOGE(TAG, "ota error: %d", ret);
-    }
+      App.scheduler.set_timeout(this, "reboot_timeout", 1000, [this]() {
+        if(!disable_ota_reboot) {
+          ESP_LOGI(TAG, "ota finished, rebooting");
+          App.safe_reboot();
+        }
+      });
+    });
   });
 
-  auto reboot_action_id = new LambdaAction<>([=]() -> void {
-    if(!disable_ota_reboot) {
-      ESP_LOGI(TAG, "ota finished, rebooting");
-      App.safe_reboot();
-    }
-  });
-
-  automation_id->add_actions({delayaction_id, ota_end_id, delayaction2_id, reboot_action_id});
+  automation_id->add_actions({ota_end_id});
 #ifdef OTA_COMPRESSION
   this->stream = z_stream{};
 #endif

--- a/components/canopen/ota/ota.h
+++ b/components/canopen/ota/ota.h
@@ -14,7 +14,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/automation.h"
 
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 
 namespace esphome {
 namespace canopen {
@@ -38,7 +38,7 @@ class CanopenOTAComponent : public ota::OTAComponent {
 
  public:
   bool disable_ota_reboot = false;
-  std::unique_ptr<esphome::ota::OTABackend> backend;
+  ota::OTABackendPtr backend;
   void setup() override;
   //   void dump_config() override;
   float get_setup_priority() const override;


### PR DESCRIPTION
    ota: update OTA finish automation to a new API
    
    It is forbidden to call register_component outside
    Python generated files. Use App.scheduler to imitate
    behavior.


    ota: update OTABackend to a new API
    
    Use the factory-based model to allocate OTA Backend.
    https://github.com/esphome/esphome/pull/14473
